### PR TITLE
Add link to Cake documentation guidelines

### DIFF
--- a/Guidelines.md
+++ b/Guidelines.md
@@ -36,6 +36,8 @@ but would provide better performance than Costura.
 
 ## Documenttion
 
+Addins should follow the [Cake Documentation Guidelines].
+
 ### Addin documentation
 
 The prefered tool for creating documentation for the addin is [Wyam].
@@ -56,4 +58,5 @@ Follow the instructions [here](https://github.com/cake-build/website/blob/develo
 [Costura.Fody NuGet package]: https://nuget.org/packages/Costura.Fody/
 [ILMerge]: https://www.microsoft.com/en-us/download/details.aspx?id=17630
 [Wyam]: https://wyam.io/ 
+[Cake Documentation Guidelines]: http://cakebuild.net/docs/contributing/documentation
 [How to create gh-pages branch]: http://www.gep13.co.uk/blog/how-to-create-gh-pages-branch


### PR DESCRIPTION
Add link to Cake documentation guidelines, which defines how to use `CakeAliasCategoryAttribute` and how to write samples